### PR TITLE
fact: add bind increment logic to serial

### DIFF
--- a/library/heylinux/myfacts
+++ b/library/heylinux/myfacts
@@ -1,40 +1,45 @@
 #!/usr/bin/python
 
+import time
 import json
 import commands
-import re
 
-def get_ansible_dns_new_serial_number(domain_name):
-    serial_number = commands.getoutput("""dig soa %s |grep -A1 'ANSWER SECTION' |tail -n 1 |awk '{print $7}'""" % (domain_name))
-    ansible_dns_new_serial_number = int(serial_number) + 1
-    return ansible_dns_new_serial_number
+from ansible.module_utils.basic import *
+from ansible.module_utils.facts import *
+
+
+def get_new_serial(domain_name):
+    cmd = "dig soa %s |grep -A1 'ANSWER SECTION' |tail -n 1 |awk '{print $7}'"
+    serial = commands.getoutput(cmd % (domain_name))
+    current_date = time.strftime('%Y%m%d')
+    if serial.startswith(current_date):
+        return str(int(serial) + 1)
+    else:
+        return "{}00".format(current_date)
+
 
 def main():
     global module
     module = AnsibleModule(
-        argument_spec = dict(
-            get_facts=dict(default="yes", required=False),
-            domain_names=dict(required=False),
-        ),
-        supports_check_mode = True,
+        argument_spec={
+            'get_facts': {'default': 'yes', 'required': False},
+            'domain_names': {'required': False},
+        },
+        supports_check_mode=True,
     )
 
-    ansible_facts_dict = {
-        "changed" : False,
+    new_serial_numbers = {}
+    if module.params['get_facts'] == 'yes' and module.params['domain_names']:
+        for domain_name in module.params['domain_names'].split(","):
+            new_serial_numbers[domain_name] = get_new_serial(domain_name)
+
+    print json.dumps({
+        "changed": False,
         "ansible_facts": {
-                "ansible_dns_new_serial_number": {}
-            }
-    }
+            "ansible_dns_new_serial_number": new_serial_numbers
+        }
+    })
 
-    if module.params['get_facts'] == 'yes':
-        if module.params['domain_names']:
-            domain_names_list = module.params['domain_names'].split(",")
-            for domain_name in domain_names_list:
-                ansible_dns_new_serial_number = get_ansible_dns_new_serial_number(domain_name)
-                ansible_facts_dict['ansible_facts']['ansible_dns_new_serial_number'][domain_name] = ansible_dns_new_serial_number
 
-    print json.dumps(ansible_facts_dict)
-
-from ansible.module_utils.basic import *
-from ansible.module_utils.facts import *
-main()
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
In `bind9`, the serial is usualy incremented the following way `YYYYMMDDxx` where xx starts at 00 and is incremented for all edits on that specific day (when editing on another day, you reset xx to 00).

The main advantage of this scheme is, that you also know the date of the last modification of your zone-file at first glance.

Cf: http://unix.stackexchange.com/questions/197988/how-to-increment-serial-number-in-bind9-dns-zone
